### PR TITLE
Fix MC version dependency issue

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx1G
 org.gradle.parallel=true
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.21
+minecraft_version=">=1.21 <=1.21.1"
 yarn_mappings=1.21+build.9
 loader_version=0.14.17
 # Mod Properties

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,7 +25,7 @@
 	"depends": {
 		"fabricloader": ">=${loader_version}",
 		"fabric": "*",
-		"minecraft": ">=1.21 <=1.21.1",
+		"minecraft": "${minecraft_version}",
 		"yet_another_config_lib_v3": "*"
 	}
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,7 +25,7 @@
 	"depends": {
 		"fabricloader": ">=${loader_version}",
 		"fabric": "*",
-		"minecraft": "${minecraft_version}",
+		"minecraft": ">=1.21 <=1.21.1",
 		"yet_another_config_lib_v3": "*"
 	}
 }


### PR DESCRIPTION
This change fixes the issue for some client being marked as 1.21 and causing Incompatible mods error being displayed on launch.

This change also adds back support for 1.21 as 1.21.1 is basically the hotfix that only changes minimal portions.

Tektonikal, remember to update this section every time when new version gets released